### PR TITLE
Fix/relative paths

### DIFF
--- a/examples/showcase/my-sources.bib
+++ b/examples/showcase/my-sources.bib
@@ -1,0 +1,5 @@
+@misc{FHICT-typst-template,
+    url={https://github.com/TomVer99/FHICT-typst-template},
+    title={FHICT typst template},
+    author={TomVer99},
+}

--- a/examples/showcase/showcase.typ
+++ b/examples/showcase/showcase.typ
@@ -31,7 +31,7 @@
   ],
   table-of-figures: true,
   table-of-listings: true,
-  bibliography-file: "my-sources.bib",
+  bibliography-file: bibliography("my-sources.bib"),
   // disable-toc: true,
   // disable-chapter-numbering: true,
   // watermark: "THIS IS A WATERMARK",

--- a/examples/starter/my-sources.bib
+++ b/examples/starter/my-sources.bib
@@ -1,0 +1,5 @@
+@misc{FHICT-typst-template,
+    url={https://github.com/TomVer99/FHICT-typst-template},
+    title={FHICT typst template},
+    author={TomVer99},
+}

--- a/examples/starter/starter.typ
+++ b/examples/starter/starter.typ
@@ -20,6 +20,6 @@
   ),
   pre-toc: [#include "./pre-toc.typ"],
   appendix: [#include "./appendix.typ"],
-  bibliography-file: "my-sources.bib",
+  bibliography-file: bibliography("my-sources.bib"),
   glossary-terms: term_list,
 )

--- a/template/fhict-template.typ
+++ b/template/fhict-template.typ
@@ -518,7 +518,8 @@
 
   // Show the bibliography
   if bibliography-file != none {
-    bibliography(bibliography-file, title: "References", style: "ieee")
+    set bibliography(title: "References", style: "ieee")
+    bibliography-file
     pagebreak()
     if print-extra-white-page == true { page_intentionally_left_blank(odd: false) }
   }

--- a/template/my-sources.bib
+++ b/template/my-sources.bib
@@ -1,5 +1,0 @@
-@misc{FHICT-typst-template,
-    url={https://github.com/TomVer99/FHICT-typst-template},
-    title={FHICT typst template},
-    author={TomVer99},
-}


### PR DESCRIPTION
Changes implementation of `bibliography-file`. Now it should be used like `bibliography-file: bibliography("my-sources.bib")`. This allows the user to use a path relative to their own file instead of the template file.

Closes #77 