### PR TITLE
Update fhict-template.typ to support code icons

### DIFF
--- a/template/fhict-template.typ
+++ b/template/fhict-template.typ
@@ -1,4 +1,5 @@
-#import "@preview/codly:1.0.0": *
+#import "@preview/codly:1.1.1": *
+#import "@preview/codly-languages:0.1.3": *
 #import "@preview/glossarium:0.5.1": make-glossary, print-glossary, gls, glspl, register-glossary
 #import "@preview/in-dexter:0.5.3": *
 #import "@preview/hydra:0.5.1": hydra
@@ -625,27 +626,13 @@
 
   show: codly-init.with()
   codly(
-    languages: (
-      rust: (name: "Rust", color: code-name-color),
-      rs: (name: "Rust", color: code-name-color),
-      cmake: (name: "CMake", color: code-name-color),
-      cpp: (name: "C++", color: code-name-color),
-      c: (name: "C", color: code-name-color),
-      py: (name: "Python", color: code-name-color),
-      java: (name: "Java", color: code-name-color),
-      js: (name: "JavaScript", color: code-name-color),
-      sh: (name: "Shell", color: code-name-color),
-      bash: (name: "Bash", color: code-name-color),
-      json: (name: "JSON", color: code-name-color),
-      xml: (name: "XML", color: code-name-color),
-      yaml: (name: "YAML", color: code-name-color),
-      typst: (name: "Typst", color: code-name-color),
-    ),
     number-format: none,
-    display-icon: false,
+    display-icon: true,
     zebra-fill: code-zebra-color,
     stroke: 1pt + code-zebra-color,
+    languages: codly-languages,
   )
+  
 
   if print-extra-white-page == true {
     page-intentionally-left-blank(newpage: false)


### PR DESCRIPTION
# Icon Support for Code Blocks

## Changes
`template/fhict-template.typ` : Added reference to `"@preview/codly-languages:0.1.3": *`, updated `codly` to `1.1.1` and replaced specific language references with the `"@preview/codly-languages:0.1.3": *` reference.

## Summary
As we talked about in private, I created a PR for this feature you didn't have time for. The icons are not resizable, though this seems to be a codly specific issue.

![image](https://github.com/user-attachments/assets/189527f0-01b4-4c52-a76d-35729f42484a)