### PR TITLE
Fix long header clipping

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -614,27 +614,36 @@
     "a4",
     background: [],
     header: [
-      #place(right + horizon, dy: 15pt)[
-        #text(10pt, fill: fontys-purple-1, font: "Roboto")[
-          #upper[*#title*]
+      #set par(justify: false)
+      #box(width: 100%)[
+        #pad(top: 2em)[
+          #grid(
+            columns: (3fr, 1fr),
+            rows: (1fr, 1fr),
+            align: alignment.bottom,
+            grid.cell(align: alignment.left)[
+              #context [
+                #let chapter = hydra(1)
+                #if chapter != none {
+                  text(10pt, fill: fontys-purple-1, font: "Roboto")[
+                    *#upper(chapter)*
+                  ]
+                }
+              ]
+            ],
+            grid.cell(align: alignment.right)[
+              #text(10pt, fill: fontys-purple-1, font: "Roboto")[
+                #upper[*#title*]
+              ]
+            ],
+            grid.cell(colspan: 2, align: alignment.top)[
+              #pad(y: 0.5em)[
+                #line(length: 100%, stroke: 1pt + fontys-purple-1)
+              ]
+            ]
+          )
         ]
       ]
-      #place(
-        left + horizon,
-        dy: 15pt,
-        [#context [
-            #let chapter = hydra(1)
-            #if chapter != none {
-              text(10pt, fill: fontys-purple-1, font: "Roboto")[
-                *#upper(chapter)*
-              ]
-            }
-          ]],
-      )
-      #place(
-        left + bottom,
-        line(length: 100%, stroke: 1pt + fontys-purple-1),
-      )
     ],
     footer: [
       #place(left + horizon, dy: -10pt, dx: -15pt, image("assets/for-society.png", height: 200%))


### PR DESCRIPTION
## Describe your changes
Previously, the header was laid out using `place`, which would use the page for layout.
However, this would cause a long enough heading text to clip with the document title within the header. This happens because `place` does not allow you to set boundaries, just to place text in a certain way.
<img width="578" alt="Current Situation" src="https://github.com/user-attachments/assets/9c686616-8492-4ee6-ad67-46bd9b7625a4" />


By defining a proper layout in which both the heading text and document title are confined in, this issue is resolved.
<img width="565" alt="Fixed Situation" src="https://github.com/user-attachments/assets/8f4cc3d3-1955-401c-b45d-4ed88d9d8a7b" />


## Checklist before requesting a review
- [x] I have tested my code
- [x] I have made corresponding changes to the documentation
